### PR TITLE
Update cumulative_Veeam_VMware_permissions_raw.txt

### DIFF
--- a/cumulative_Veeam_VMware_permissions_raw.txt
+++ b/cumulative_Veeam_VMware_permissions_raw.txt
@@ -29,6 +29,7 @@ Host.Config.Network
 Host.Config.Patch
 Host.Config.Storage
 InventoryService.Tagging.AttachTag
+InventoryService.Tagging.ObjectAttachable
 Network.Assign
 Network.Config
 Resource.AssignVMToPool


### PR DESCRIPTION
According to https://helpcenter.veeam.com/docs/backup/permissions/cumulativepermissions.html?ver=120 for vSphere Tagging two permissions are needed: Assign or Unassign vSphere Tag: InventoryService.Tagging.AttachTag (already in file) Assign or Unassign vSphere Tag on Object: InventoryService.Tagging.ObjectAttachable (added)